### PR TITLE
Returning used disk space

### DIFF
--- a/isr.cpp
+++ b/isr.cpp
@@ -154,6 +154,7 @@ string isr_disk_data(vector<disk_info> * _disks, int _init, const string cf_disk
 	stringstream temp;
 	vector<string> conf_label;
 	string disk_label, disk_label_custom, disk_uuid;
+	int disk_size, disk_percent, disk_usage;
 	
 	if(0 == _disks->size()) return temp.str();
 	
@@ -200,8 +201,12 @@ string isr_disk_data(vector<disk_info> * _disks, int _init, const string cf_disk
 			disk_uuid = (*cur).uuid;
 		else
 			disk_uuid = (*cur).device;
+
+		disk_size = (*cur).history.front().f / 1000;
+		disk_percent = (*cur).history.front().p;
+		disk_usage = disk_size * disk_percent / 100;
 		
-		temp << "<d n=\"" << disk_label << "\" uuid=\"" << disk_uuid << "\" f=\"" << (*cur).history.front().f / 1000 << "\" p=\"" << (*cur).history.front().p << "\"></d>";
+		temp << "<d n=\"" << disk_label << "\" uuid=\"" << disk_uuid << "\" f=\"" << disk_size << "\" p=\"" << disk_percent << "\" u=\"" << disk_usage << "\"></d>";
 	}
 	
 	temp << "</DISKS>";


### PR DESCRIPTION
iStat for iOS accepts an attribute (`u`) for used disk space in megabytes.  This PR adds in some quick math to pass back that attribute.  Screenshot attached shows difference on client.
![2014-09-28 at 12 04 am](https://cloud.githubusercontent.com/assets/39943/4433276/23183c2a-46cd-11e4-9e3d-fe7c748d072b.png)
